### PR TITLE
add apple meta tag to be full screen from homescreen

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
+    <meta name="apple-mobile-web-app-capable" content="yes">
     <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">


### PR DESCRIPTION
Before this screen, saving to homescreen on iOS Safari is just a bookmark. A “mobile capable” site is slightly different, in that it opens standalone without actually showing Safari, and getting an own spot in the app switcher