### PR TITLE
Improve accessibility in css

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -228,7 +228,7 @@ body {
 
 .max-velocity-unit {
   display: inline-block;
-  font-size: 12px;
+  font-size: 20px;
 }
 
 #maxVelocity {


### PR DESCRIPTION
Increasing font-size of `.max-velocity-unit` to adhere to a11y standards of contrast. Should close #54 

Optionally, the background of the footer could have been made darker.