### PR TITLE
Update container width to be at most 90% of viewport

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -97,13 +97,22 @@ body {
   left: 50%;
   transform: translateY(-50%) translateX(-50%);
   width: 400px;
-  height: 400px;
-  display: flex;
+  max-width: 90%;
+}
+
+#spinner-container::before {
+  content: "";
+  display: block;
+  padding-top: 100%;
 }
 
 #spinner {
   will-change: transform;
-  flex: auto;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
 }
 
 #trace-slow,
@@ -157,6 +166,7 @@ body {
   position: absolute;
   top: 0;
   left: 0;
+  max-width: 100%;
 }
 
 #footer {


### PR DESCRIPTION
Since the size is a flat 400px, the spinner is overflowing on smaller viewports (360px below, but this gets worse when lower) :
![spinner_before](https://user-images.githubusercontent.com/3253522/26921274-ce474818-4c3b-11e7-9290-64abe2c59117.png)

I made a few tweaks to the css file so that it takes at most 90% of the viewport :
![spinner_after](https://user-images.githubusercontent.com/3253522/26921323-f7f062c6-4c3b-11e7-9f7e-fc2846ae9fbe.png)

It is a bit of a hack so i'm not sure you would accept this :sweat_smile: but it is working consistently on all devices that I could try it on.