### PR TITLE
Fix long press opening download menu

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -157,6 +157,7 @@ body {
   position: absolute;
   top: 0;
   left: 0;
+  pointer-events: none;
 }
 
 #footer {


### PR DESCRIPTION
The idea is to fix #40.

Adding `pointer-events: none;`  directly to the img tag should do it, and it shouldn't affect the events for actually rotating and stopping the spinner.

Tested on desktop and android, but once again I don't have an iOS device to check :disappointed: hoping someone can help with this, else I'll try to get my hands on an iphone.